### PR TITLE
fix: LocalDataStorage storage_format attribute error

### DIFF
--- a/src/storage/local_data_storage.py
+++ b/src/storage/local_data_storage.py
@@ -50,7 +50,7 @@ class LocalDataStorage:
             raise ValueError("Data must be a dictionary or a list of dictionaries.")
 
         target_file_path = file_path or self.default_file_path
-        format_to_use = storage_format.lower() if storage_format else self.storage_format
+        format_to_use = storage_format.lower() if storage_format else self.default_storage_format.value
 
         if format_to_use not in [f.value for f in StorageFormat]:
             raise ValueError(f"Invalid storage format. Supported formats are: {', '.join(f.value for f in StorageFormat)}.")


### PR DESCRIPTION
## Bug Fix  
The `LocalDataStorage` class was throwing an `AttributeError` because it tried to access `self.storage_format`, which doesn’t exist. 

The error: "ERROR:OddsPortalScrapperApp:Error during data storage: 'LocalDataStorage' object has no attribute 'storage_format'" 

### **Fix**  
- Changed `save_data` to use `self.default_storage_format` (the correct attribute from `__init__`).  
- Made sure `StorageFormat` enum values are handled properly with `.value`.  

### **Testing**  
I tested by saving data in both CSV and JSON formats and confirmed the correct format is used, whether set explicitly or inherited from `default_storage_format`