### PR TITLE
Fix: Corrected Dockerfile and command syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ENV LAMBDA_TASK_ROOT=/var/task
 WORKDIR "${LAMBDA_TASK_ROOT}"
 
 # Copy application files
-COPY src ${LAMBDA_TASK_ROOT}
-COPY pyproject.toml uv.lock README.md LICENSE.txt ${LAMBDA_TASK_ROOT}
+COPY src ${LAMBDA_TASK_ROOT}/src
+COPY pyproject.toml uv.lock README.md LICENSE.txt ${LAMBDA_TASK_ROOT}/
 
 # Install dependencies
 RUN uv sync --frozen
@@ -32,4 +32,5 @@ FROM base AS local-dev
 ENV PATH="${LAMBDA_TASK_ROOT}/.venv/bin:$PATH"
 
 # Set default command for local testing
-CMD ["xvfb-run", "--", "python3", "-m", "main"]
+CMD ["xvfb-run", "--", "python3", "-m", "src.main"]
+

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ OddsHarvester is compatible with Docker, allowing you to run the application sea
 
 3. **Run the Container**
    Start a Docker container based on the built image. Map the necessary ports if required and specify any volumes to persist data. Pass any CLI arguments (e.g., `scrape_upcoming`) as part of the Docker run command:
-   `docker run --rm odds-harvester:latest python3 -m main scrape_upcoming --sport football --date 20250125 --markets 1x2 --storage local --file_path output.json --headless`
+   `docker run --rm odds-harvester:local python3 -m src.main scrape_upcoming --sport football --date 20250903 --markets 1x2 --storage local --file_path output.json --headless`
 
 4. **Interactive Mode for Debugging**
    If you need to debug or run commands interactively: `docker run --rm -it odds-harvester:latest /bin/bash`


### PR DESCRIPTION
This PR addresses several critical issues in the Dockerfile that would prevent the image from building correctly or functioning as intended for local development.

**1. Fixed COPY Command Syntax**
The COPY commands on lines 12 and 13 were updated to correctly handle file paths. The destination was modified to maintain the intended directory structure, ensuring the application can correctly locate its modules.

**2. Corrected Module Path in CMD Command**
The CMD command for the local-dev stage was updated to correctly reference the Python module. The previous command (python3 -m main) would fail because the main.py file is located within the src subdirectory. The corrected command (python3 -m src.main) now properly points to the module's location.

I also updated the README, the container tag "latest" was not the same given in the command before.
Tested on W11 and Ubuntu Server.