### PR TITLE
Fix pagination gap filling, scroll lazy-loading, and current season URL

### DIFF
--- a/src/oddsharvester/core/browser_helper.py
+++ b/src/oddsharvester/core/browser_helper.py
@@ -408,9 +408,18 @@ class BrowserHelper:
 
         self.logger.info(f"Initial page height: {last_height}")
 
+        scroll_step = 500
+        current_scroll_pos = 0
+
         while time.time() < end_time:
-            # Scroll to bottom
-            await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+            # Scroll incrementally to trigger lazy-loading content
+            page_height = await page.evaluate("document.body.scrollHeight")
+            if current_scroll_pos < page_height:
+                current_scroll_pos = min(current_scroll_pos + scroll_step, page_height)
+                await page.evaluate(f"window.scrollTo(0, {current_scroll_pos})")
+            else:
+                # Already at bottom, nudge to trigger any remaining loads
+                await page.evaluate(f"window.scrollTo(0, {page_height})")
             await page.wait_for_timeout(scroll_pause_time * 1000)
 
             new_height = await page.evaluate("document.body.scrollHeight")

--- a/src/oddsharvester/core/odds_portal_scraper.py
+++ b/src/oddsharvester/core/odds_portal_scraper.py
@@ -304,34 +304,37 @@ class OddsPortalScraper(BaseScraper):
 
     def _fill_pagination_gaps(self, raw_pages: list[int]) -> list[int]:
         """
-        Sort, deduplicate, and cap discovered pagination pages.
+        Sort, deduplicate, fill gaps, and cap discovered pagination pages.
 
-        Trusts the pages discovered in the pagination HTML rather than generating
-        phantom pages to fill gaps (e.g., [1, 2, 3, 27] stays as-is instead of
-        becoming [1..27]).
+        OddsPortal renders pagination with an ellipsis for large page ranges
+        (e.g. ``[1,2,3,...,28]``), so the HTML only contains the endpoints.
+        This method fills the gap so all intermediate pages are scraped.
 
         Args:
             raw_pages (List[int]): Raw page numbers found in pagination.
 
         Returns:
-            List[int]: Sorted, deduplicated list of pages capped at MAX_PAGINATION_PAGES.
+            List[int]: Contiguous list of pages from 1..max, capped at MAX_PAGINATION_PAGES.
         """
         if len(raw_pages) <= 1:
             return raw_pages
 
-        # Sort and deduplicate
-        unique_pages = sorted(set(raw_pages))
-        self.logger.info(f"Discovered {len(unique_pages)} unique pagination pages: {unique_pages}")
+        max_page = max(raw_pages)
+        all_pages = list(range(1, max_page + 1))
+        self.logger.info(
+            f"Pagination HTML showed {sorted(set(raw_pages))}, "
+            f"filling to contiguous range 1..{max_page} ({len(all_pages)} pages)"
+        )
 
         # Apply safety cap
-        if len(unique_pages) > MAX_PAGINATION_PAGES:
+        if len(all_pages) > MAX_PAGINATION_PAGES:
             self.logger.warning(
-                f"Pagination exceeds safety cap ({len(unique_pages)} > {MAX_PAGINATION_PAGES}). "
+                f"Pagination exceeds safety cap ({len(all_pages)} > {MAX_PAGINATION_PAGES}). "
                 f"Limiting to first {MAX_PAGINATION_PAGES} pages."
             )
-            unique_pages = unique_pages[:MAX_PAGINATION_PAGES]
+            all_pages = all_pages[:MAX_PAGINATION_PAGES]
 
-        return unique_pages
+        return all_pages
 
     async def _collect_match_links(self, base_url: str, pages_to_scrape: list[int]) -> LinkCollectionResult:
         """

--- a/src/oddsharvester/core/url_builder.py
+++ b/src/oddsharvester/core/url_builder.py
@@ -1,5 +1,5 @@
+from datetime import UTC, datetime
 import re
-from datetime import datetime, timezone
 
 from oddsharvester.utils.constants import ODDSPORTAL_BASE_URL
 from oddsharvester.utils.league_aliases import get_league_slug_for_season
@@ -60,7 +60,7 @@ class URLBuilder:
                 return f"{base_url}-{start_year}/results/"
 
             # OddsPortal serves the current season at the base URL (no year suffix)
-            current_year = datetime.now(timezone.utc).year
+            current_year = datetime.now(UTC).year
             if end_year == current_year:
                 return f"{base_url}/results/"
 

--- a/src/oddsharvester/core/url_builder.py
+++ b/src/oddsharvester/core/url_builder.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timezone
 
 from oddsharvester.utils.constants import ODDSPORTAL_BASE_URL
 from oddsharvester.utils.league_aliases import get_league_slug_for_season
@@ -57,6 +58,11 @@ class URLBuilder:
             # Special handling for baseball leagues
             if sport.lower() == "baseball":
                 return f"{base_url}-{start_year}/results/"
+
+            # OddsPortal serves the current season at the base URL (no year suffix)
+            current_year = datetime.now(timezone.utc).year
+            if end_year == current_year:
+                return f"{base_url}/results/"
 
             return f"{base_url}-{season}/results/"
 

--- a/tests/core/test_odds_portal_scraper.py
+++ b/tests/core/test_odds_portal_scraper.py
@@ -427,13 +427,13 @@ class TestFillPaginationGaps:
         """Consecutive pages are returned sorted."""
         assert scraper._fill_pagination_gaps([3, 1, 2]) == [1, 2, 3]
 
-    def test_no_gap_filling(self, scraper):
-        """Pages with gaps are NOT filled — trusts discovered pages."""
+    def test_gap_filling(self, scraper):
+        """Gaps between discovered pages are filled (OddsPortal ellipsis)."""
         result = scraper._fill_pagination_gaps([1, 2, 3, 27])
-        assert result == [1, 2, 3, 27]
+        assert result == list(range(1, 28))
 
     def test_deduplication(self, scraper):
-        """Duplicate pages are removed."""
+        """Duplicate pages are deduplicated via max()."""
         assert scraper._fill_pagination_gaps([1, 2, 2, 3, 3]) == [1, 2, 3]
 
     def test_safety_cap(self, scraper):


### PR DESCRIPTION
## 📋 Description

Three fixes for issues that cause historic scraping to silently miss most matches in a season:

**1. Pagination gap filling** — OddsPortal renders pagination with an ellipsis for large page ranges (e.g. `[1, 2, 3, ..., 28]`), so only the visible page numbers appear in the HTML. `_fill_pagination_gaps()` trusted only those visible pages, missing all intermediate ones (e.g. pages 4–27 of 28). Now fills the full contiguous range `1..max_page`.

**2. Scroll lazy-loading** — `scroll_until_loaded()` jumped directly to `document.body.scrollHeight`, which doesn't trigger OddsPortal's lazy-loader. Pages returned ~5 rows instead of ~50. Now uses incremental 500px scroll steps to trigger content loading.

**3. Current season URL** — OddsPortal serves the in-progress season at the base URL without a year suffix (e.g. `/football/england/premier-league/results/` not `.../premier-league-2025-2026/results/`). The URL builder now detects when the requested season's end year matches the current calendar year and omits the suffix.

---

## 🔍 Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)

---

## ✅ Checklist

- [x] I have tested my changes locally and ensured they work as expected.
- [x] I have added tests that prove my fix/feature works as intended.
- [x] My code follows the project's code style and guidelines.

---

## 🚦 How Has This Been Tested?

- Existing pagination tests updated to verify gap filling behaviour
- Full unit test suite passes (542 passed, 5 skipped)
- Ruff lint and format checks pass
- Tested against EPL 2021-2022 through 2025-2026 seasons — previously returning ~60 matches per season (3 pages × ~20), now correctly returning 350-410

---

## 🗒️ Additional Notes

The pagination change intentionally reverses a previous design choice. The prior implementation had a comment noting it "trusts the pages discovered in the pagination HTML rather than generating phantom pages." This is correct when all pages are visible, but OddsPortal uses an ellipsis for ranges beyond ~5 pages, so the HTML only contains the endpoints. For a 28-page season, only pages [1, 2, 3, 27, 28] were scraped.