### PR TITLE
fix(deps): add tzdata so zoneinfo works on Windows, unblocking historic scraping (#71)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "click>=8.1.0",
     "lxml>=6.0.2",
     "playwright>=1.57.0",
-    "pytz>=2025.2"
+    "pytz>=2025.2",
+    "tzdata>=2025.2"
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -330,6 +330,7 @@ dependencies = [
     { name = "lxml" },
     { name = "playwright" },
     { name = "pytz" },
+    { name = "tzdata" },
 ]
 
 [package.optional-dependencies]
@@ -354,6 +355,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.10" },
+    { name = "tzdata", specifier = ">=2025.2" },
 ]
 
 [[package]]
@@ -612,6 +614,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Reported in #71. On Windows, `historic` scraping fails for every match with `H2H fragment resolution failed`, while `upcoming` works fine.

## Root cause

OddsHarvester resolves timezones via stdlib `zoneinfo`, which on Windows has no system tz database and depends on the `tzdata` PyPI package. `tzdata` was not declared as a dependency, so every `ZoneInfo(...)` call — including the UTC fallback — raised `No time zone found with key UTC`.

That broke `_parse_match_date_from_dom`, which historic H2H scraping uses to discriminate the fragment-targeted match from the stale SSR payload. With the DOM date unavailable, the scraper always fell into the hash-resync path (impossible for historic matches) and dropped the match. `upcoming` survived because it falls back to the embedded JSON `startDate`, which doesn't depend on `tzdata`.

## Fix

Add `tzdata` to runtime dependencies. Resolves both the timezone warnings and the historic scraping failure on Windows. No behavior change on Linux/macOS (system tz database already present).

https://claude.ai/code/session_01Tu3y3LeNocZEuJgEtxnc6X
