### PR TITLE
fix: use stdlib UTC constant instead of ZoneInfo("UTC") for tz fallback

### DIFF
--- a/src/oddsharvester/core/base_scraper.py
+++ b/src/oddsharvester/core/base_scraper.py
@@ -93,9 +93,9 @@ def _parse_date_header(header_text: str, tz_name: str | None = None) -> date | N
         text = text.split(" - ", 1)[0].strip()
 
     try:
-        tz = ZoneInfo(tz_name) if tz_name else ZoneInfo("UTC")
+        tz = ZoneInfo(tz_name) if tz_name else UTC
     except (ZoneInfoNotFoundError, ValueError):
-        tz = ZoneInfo("UTC")
+        tz = UTC
 
     now_date = datetime.now(tz).date()
 
@@ -701,7 +701,7 @@ class BaseScraper:
             return ZoneInfo(tz_id)
         except ZoneInfoNotFoundError:
             self.logger.warning(f"Unknown timezone '{tz_id}', falling back to UTC for DOM date parsing")
-            return ZoneInfo("UTC")
+            return UTC
 
     def _parse_match_date_from_dom(self, soup: BeautifulSoup) -> str | None:
         """

--- a/tests/core/test_base_scraper.py
+++ b/tests/core/test_base_scraper.py
@@ -1,7 +1,7 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 import json as _json
 from unittest.mock import AsyncMock, MagicMock, patch
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from bs4 import BeautifulSoup
 from playwright.async_api import Page, TimeoutError
@@ -1152,8 +1152,45 @@ def test_resolved_browser_timezone_falls_back_on_unknown(setup_base_scraper_mock
     mocks["playwright_manager_mock"].timezone_id = "Not/A/Real/Zone"
     with caplog.at_level(logging.WARNING):
         result = scraper._resolved_browser_timezone()
-    assert result == ZoneInfo("UTC")
+    # Fallback returns the stdlib UTC constant (datetime.timezone.utc), which is
+    # not equal to ZoneInfo("UTC"); assert on the offset instead so this stays
+    # robust to either tzinfo implementation.
+    assert result.utcoffset(datetime(2024, 1, 1)) == timedelta(0)
     assert any("Not/A/Real/Zone" in rec.message for rec in caplog.records)
+
+
+def test_resolved_browser_timezone_survives_missing_tzdata(setup_base_scraper_mocks, caplog):
+    """Regression: when the tz database is unavailable, ZoneInfo("UTC") itself
+    raises ZoneInfoNotFoundError. The fallback must not construct a ZoneInfo at
+    all (it must return the stdlib UTC constant) or it will crash the same way.
+    """
+    import logging
+
+    mocks = setup_base_scraper_mocks
+    scraper = mocks["scraper"]
+    mocks["playwright_manager_mock"].timezone_id = "UTC"
+
+    def _no_tzdata(_name):
+        raise ZoneInfoNotFoundError(f"No time zone found with key {_name}")
+
+    with patch("oddsharvester.core.base_scraper.ZoneInfo", side_effect=_no_tzdata), caplog.at_level(logging.WARNING):
+        result = scraper._resolved_browser_timezone()
+    assert result is UTC
+    assert result.utcoffset(datetime(2024, 1, 1)) == timedelta(0)
+
+
+def test_parse_date_header_survives_missing_tzdata():
+    """Regression: with tz_name="UTC" and no tz database installed, ZoneInfo
+    raises for every name including "UTC". The fallback must return a date
+    derived from the stdlib UTC constant, not crash.
+    """
+
+    def _no_tzdata(_name):
+        raise ZoneInfoNotFoundError(f"No time zone found with key {_name}")
+
+    today_utc = datetime.now(UTC).date()
+    with patch("oddsharvester.core.base_scraper.ZoneInfo", side_effect=_no_tzdata):
+        assert _parse_date_header("Today, 14 Apr", tz_name="UTC") == today_utc
 
 
 def _make_date_html(date_str: str = "06 Aug 2022,", time_str: str = "11:30") -> str:


### PR DESCRIPTION
## 📋 Description

The two UTC fallback paths in `base_scraper.py` — `_resolved_browser_timezone` (L704) and the module-level `_parse_date_header` (L96) — construct `ZoneInfo("UTC")`. On systems where the tz database is unavailable (slim containers / minimal images without `tzdata`), `ZoneInfo` raises `ZoneInfoNotFoundError` for **every** name, including `"UTC"`. The fallback that is supposed to guarantee a valid tzinfo instead raises.

This breaks historic scraping silently and at scale: when the fallback raises, `_parse_match_date_from_dom` returns `None`, so every match on a historic results page is misclassified as needing an H2H fragment resync (the "case-b" path) and then dropped after the resync timeout. On affected environments this reproduces the symptom of #71 across all sports — 100% of MLB matches and ~75-80% of NBA/NHL matches silently dropped — while environments with a tz database see no error, which is why it's environment-dependent.

Fix: replace `ZoneInfo("UTC")` with the stdlib `datetime.timezone.utc` constant (imported as `UTC`), which never raises and behaves identically for the offset-only date math these helpers perform.

Fixes #71 (the environment-dependent variant — the fragment-resync misclassification caused by the DOM date returning `None`).

## 🔍 Type of Change

- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Test improvement or addition

## ✅ Checklist

- [x] I have tested my changes locally and ensured they work as expected.
- [x] I have added necessary documentation (if applicable).
- [x] I have added tests that prove my fix/feature works as intended.
- [x] My code follows the project's code style and guidelines.
- [x] I have updated the README (if applicable).

## 🚦 How Has This Been Tested

- `uv run pytest tests/core/test_base_scraper.py -q --ignore=tests/integration/` → 108 passed.
- `uv run ruff check` and `uv run ruff format --check` on both changed files → clean.
- New regression tests patch `ZoneInfo` to raise for every name (simulating a missing tz database, including for `"UTC"`) and assert the fallbacks return the stdlib UTC constant instead of crashing.
- End-to-end: with this patch applied to a local fork, a 1-page `historic` MLB scrape on the current 2026 season went from 0/50 successful matches (pre-patch) to 42/50 successful with 0 fragment-resolution failures — the dropped-matches symptom disappeared.

## 🔗 Related Issues or Discussions

Fixes #71

## 🗒️ Additional Notes

- The existing `test_resolved_browser_timezone_falls_back_on_unknown` asserted `result == ZoneInfo("UTC")`; since `datetime.timezone.utc` is not equal to `ZoneInfo("UTC")`, it now asserts on `utcoffset(...) == timedelta(0)`, which is robust to either tzinfo implementation.
- This addresses the environment-dependent root cause (DOM date → `None` → universal case-b misclassification). Any residual fragment-resync failures on matches whose SSR genuinely shows the *upcoming* meeting (true case-b) are a separate concern and intentionally left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
